### PR TITLE
Fixed requirements.txt to include pywin32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ keyboard>=0.13.5
 pystray>=0.19.4
 requests>=2.31.0
 pythonnet>=3.0.1
+pywin32>=302


### PR DESCRIPTION
Hi,
When installing the provided requirements.txt, mini.py would throw an error because of the missing module "win32gui".
I added pywin32 to the requirements in order to have the module installed with the requirements

Thank you for your work :)
Riccardo